### PR TITLE
Output File Next to Input File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Graphviz.nvim
 
-A very simple wrapper for [graphviz](https://graphviz.org/). I hope my first plugin helps someone.
+A very simple wrapper for [graphviz](https://graphviz.org/).
 
 > [!NOTE]
-> This plugin require [graphviz](https://graphviz.org/)
+> This plugin requires [graphviz](https://graphviz.org/)
 
 ## Installation
 
@@ -17,7 +17,7 @@ A very simple wrapper for [graphviz](https://graphviz.org/). I hope my first plu
 }
 ```
 
-- **default config**
+# Configuration
 
 ```lua
 require("graphviz").setup({
@@ -26,13 +26,13 @@ require("graphviz").setup({
 })
 ```
 
-## How to use
+## Usage
 
 > [!NOTE]
-> Unfortunately, this plugin only works with `dot` command.
+> Unfortunately, this plugin only works with the `dot` command.
 
-The plugin have two commands to play. These commands are only visible on **dot** and **gv** files.
-`Graphviz.nvim` use `vim.notify` for error notifications on export.
+The plugin has two only commands which are only available to files with the **.dot** and **.gv** file extensions.  
+`Graphviz.nvim` uses `vim.notify` for error notifications on export.
 
 - `GraphExport` can accept 1 argument for the format, but if no argument is provided, it will use the default **setup** value.
 
@@ -40,12 +40,12 @@ The plugin have two commands to play. These commands are only visible on **dot**
 :GraphExport format
 ```
 
-`GraphExport` only export the actual file to preferred format.
+`GraphExport` only exports the actual file to preferred format.
 
-- `GraphPreview` don't take arguments, but you can change the format in setup
+- `GraphPreview` doesn't take arguments, but you can change the output format within the setup function.
 
 ```vim
 :GraphPreview
 ```
 
-`GraphPreview` also exports, but it works automatically. It exports whenever you save, so you don’t have to run the `GraphExport` command every time you want to see the results.
+`GraphPreview` also exports, but it works automatically whenever you save, so you don’t have to run the `GraphExport` command every time you want to see the results.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A very simple wrapper for [graphviz](https://graphviz.org/).
 ```lua
 {
     "izocha/graphviz.nvim",
-    ft = {"dot"},
+    ft = { "dot" },
     config = true
 }
 ```
@@ -31,7 +31,7 @@ require("graphviz").setup({
 > [!NOTE]
 > Unfortunately, this plugin only works with the `dot` command.
 
-The plugin has two only commands which are only available to files with the **.dot** and **.gv** file extensions.  
+The plugin has only two commands which are only available to files with the **.dot** and **.gv** file extensions.  
 `Graphviz.nvim` uses `vim.notify` for error notifications on export.
 
 - `GraphExport` can accept 1 argument for the format, but if no argument is provided, it will use the default **setup** value.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A very simple wrapper for [graphviz](https://graphviz.org/).
 }
 ```
 
-# Configuration
+## Configuration
 
 ```lua
 require("graphviz").setup({

--- a/lua/graphviz.lua
+++ b/lua/graphviz.lua
@@ -1,52 +1,18 @@
--- local utils = require("graphviz.utils")
--- local commands = require("graphviz.commands")
-
 ---@type Graphviz.config
 local defaults = {
 	format = "pdf",
 	preview = "pdf",
 }
 
-
 ---@class Graphviz.config
 ---@field format string
 ---@field preview string
-
 local M = {}
 
 M.config = defaults
 
 function M.setup(args)
 	M.config = vim.tbl_deep_extend("force", M.config, args or {})
-	-- M.user_commands()
 end
-
--- function M.user_commands()
--- 	local buf_user_command = vim.api.nvim_buf_create_user_command
--- 	-- Create commands ONLY for dot files
--- 	vim.api.nvim_create_autocmd("FileType", {
--- 		pattern = "dot",
--- 		-- group = utils.group,
--- 		callback = function()
--- 			buf_user_command(0, "GraphExport", function(opts)
--- 				local args = opts.fargs[1] or M.config.format
--- 				commands.graph_export(args)
--- 			end, {
--- 				desc = "Export graph",
--- 				--NOTE:-- Why "*"?, because this allow me to use default values
--- 				nargs = "*",
--- 				complete = function()
--- 					return utils.args_complete()
--- 				end,
--- 			})
---
--- 			buf_user_command(0, "GraphPreview", function()
--- 				commands.graph_preview(M.config.preview)
--- 			end, {
--- 				desc = "Graphviz preview on save",
--- 			})
--- 		end,
--- 	})
--- end
 
 return M

--- a/lua/graphviz/commands.lua
+++ b/lua/graphviz/commands.lua
@@ -3,18 +3,18 @@ local utils = require("graphviz.utils")
 local M = {}
 
 function M.graph_preview(format)
-	local buf_name, buf_path = utils.get_file()
+	local _, buf_path = utils.get_file()
 	local format_arg = "-T" .. format
-	local output = buf_name .. "." .. format
+	local output = buf_path .. "." .. format
 	local command = { "dot", buf_path, format_arg, "-o", output }
 	utils.export(command)
 	utils.on_save(command)
 end
 
 function M.graph_export(format)
-	local buf_name, buf_path = utils.get_file()
+	local _, buf_path = utils.get_file()
 	local format_arg = "-T" .. format
-	local output = buf_name .. "." .. format
+	local output = buf_path .. "." .. format
 	local command = { "dot", buf_path, format_arg, "-o", output }
 	utils.export(command)
 end


### PR DESCRIPTION
Before, when NeoVim was opened in a project via `nvim .` and I used `:GraphvizExport` or `:GraphvizPreview` on a file `doc/graph.dot` for example, the output file would be `PROJECT_ROOT/graph.pdf`.

With this fix the output file will be `PROJECT_ROOT/doc/graph.dot.pdf`.

This pull request also fixes some spelling and grammar within the README.